### PR TITLE
Added orders.json data and items.json data

### DIFF
--- a/utils/sample_data/items.json
+++ b/utils/sample_data/items.json
@@ -1,0 +1,58 @@
+{
+  "-NspVTS1bBhkEqIHZPQw": {
+    "itemName": "Hawaiian Pizza (Ham, Pineapple)",
+    "itemPrice": 11,
+    "orderID": "9636673780",
+    "firebaseKey": "-NspVTS1bBhkEqIHZPQw",
+    "uid": null
+  },
+  "-NspVTS1bBhkEqIHZPQx": {
+    "itemName": "Garlic Parmesan Wings",
+    "itemPrice": 20,
+    "orderID": "2903812977",
+    "firebaseKey": "-NspVTS1bBhkEqIHZPQx",
+    "uid": null
+  },
+  "-NspVTS29Ffzp3eJP7yk": {
+    "itemName": "Spinach and artichoke dip",
+    "itemPrice": 5,
+    "orderID": "1203827679",
+    "firebaseKey": "-NspVTS29Ffzp3eJP7yk",
+    "uid": null
+  },
+  "-NspVTS3C3ajOg_NP4-O": {
+    "itemName": "Cheesy Bread Sticks",
+    "itemPrice": 23,
+    "orderID": "0081480334",
+    "firebaseKey": "-NspVTS3C3ajOg_NP4-O",
+    "uid": null
+  },
+  "-NspVTS4xOnyHd3_xKq7": {
+    "itemName": "Buffalo Wings",
+    "itemPrice": 14,
+    "orderID": "4295554979",
+    "firebaseKey": "-NspVTS4xOnyHd3_xKq7",
+    "uid": null
+  },
+  "-NspVTS4xOnyHd3_xKq8": {
+    "itemName": "Pepperoni stuffed crust",
+    "itemPrice": 7,
+    "orderID": "0570319692",
+    "firebaseKey": "-NspVTS4xOnyHd3_xKq8",
+    "uid": null
+  },
+  "-NspVTS5ZQhun-T7fZ0l": {
+    "itemName": "Caesar salad",
+    "itemPrice": 21,
+    "orderID": "5583125594",
+    "firebaseKey": "-NspVTS5ZQhun-T7fZ0l",
+    "uid": null
+  },
+  "-NspVTS6IYrxt96aGqwB": {
+    "itemName": "Grizzly Beer",
+    "itemPrice": 22,
+    "orderID": "7294223971",
+    "firebaseKey": "-NspVTS6IYrxt96aGqwB",
+    "uid": null
+  }
+}

--- a/utils/sample_data/orders.json
+++ b/utils/sample_data/orders.json
@@ -1,0 +1,146 @@
+{
+  "-NspU6A9EH-xbgpmjB0Z": {
+    "name": "Zach Colburn",
+    "isOpen": true,
+    "customerPhone": "(561) 254-8390",
+    "customerEmail": "eamies0@bigcartel.com",
+    "orderType": "Mobile",
+    "firebaseKey": "-NspU6A9EH-xbgpmjB0Z",
+    "uid": null
+  },
+  "-NspU6AA4VtVeaSOt0W2": {
+    "name": "Zach Colburn",
+    "isOpen": true,
+    "customerPhone": "(199) 430-5595",
+    "customerEmail": "adahlberg1@latimes.com",
+    "orderType": "cash",
+    "firebaseKey": "-NspU6AA4VtVeaSOt0W2",
+    "uid": null
+  },
+  "-NspU6ABgKcxKU2fmxrb": {
+    "name": "Zach Colburn",
+    "isOpen": true,
+    "customerPhone": "(811) 635-1416",
+    "customerEmail": "pcowles2@wordpress.org",
+    "orderType": "credit",
+    "firebaseKey": "-NspU6ABgKcxKU2fmxrb",
+    "uid": null
+  },
+  "-NspU6ACu9uzYuKLsoH9": {
+    "name": "Zach Colburn",
+    "isOpen": true,
+    "customerPhone": "(312) 242-5849",
+    "customerEmail": "aandrejs3@mapquest.com",
+    "orderType": "check",
+    "firebaseKey": "-NspU6ACu9uzYuKLsoH9",
+    "uid": null
+  },
+  "-NspU6ADS5JIgE39GiOX": {
+    "name": "Ross Morgan",
+    "isOpen": true,
+    "customerPhone": "(589) 865-4990",
+    "customerEmail": "nheaselgrave4@apache.org",
+    "orderType": "credit",
+    "firebaseKey": "-NspU6ADS5JIgE39GiOX",
+    "uid": null
+  },
+  "-NspU6AFl00lhYvyK8Oc": {
+    "name": "Ross Morgan",
+    "isOpen": true,
+    "customerPhone": "(828) 886-9732",
+    "customerEmail": "scroci5@qq.com",
+    "orderType": "Mobile",
+    "firebaseKey": "-NspU6AFl00lhYvyK8Oc",
+    "uid": null
+  },
+  "-NspU6AGrQIp0glzhySX": {
+    "name": "Ross Morgan",
+    "isOpen": true,
+    "customerPhone": "(519) 972-2011",
+    "customerEmail": "anoir6@time.com",
+    "orderType": "cash",
+    "firebaseKey": "-NspU6AGrQIp0glzhySX",
+    "uid": null
+  },
+  "-NspU6AHO1YpLxWZ4gUI": {
+    "name": "Ross Morgan",
+    "isOpen": true,
+    "customerPhone": "(737) 424-4371",
+    "customerEmail": "fmanilove7@springer.com",
+    "orderType": "debit",
+    "firebaseKey": "-NspU6AHO1YpLxWZ4gUI",
+    "uid": null
+  },
+  "-NspU6AIPICqaXVtw3UG": {
+    "name": "Taylor Seager",
+    "isOpen": true,
+    "customerPhone": "(526) 517-1232",
+    "customerEmail": "amackee8@state.gov",
+    "orderType": "Mobile",
+    "firebaseKey": "-NspU6AIPICqaXVtw3UG",
+    "uid": null
+  },
+  "-NspU6AJLdXX1Hn9YZTC": {
+    "name": "Taylor Seager",
+    "isOpen": true,
+    "customerPhone": "(274) 427-0906",
+    "customerEmail": "lcerith9@foxnews.com",
+    "orderType": "check",
+    "firebaseKey": "-NspU6AJLdXX1Hn9YZTC",
+    "uid": null
+  },
+  "-NspU6AKC4FC2-3wJZq7": {
+    "name": "Taylor Seager",
+    "isOpen": true,
+    "customerPhone": "(812) 430-6897",
+    "customerEmail": "sgaleroa@guardian.co.uk",
+    "orderType": "cash",
+    "firebaseKey": "-NspU6AKC4FC2-3wJZq7",
+    "uid": null
+  },
+  "-NspU6ALw-cNIgTkRE27": {
+    "name": "Taylor Seager",
+    "isOpen": true,
+    "customerPhone": "(851) 256-4790",
+    "customerEmail": "apudsallb@1688.com",
+    "orderType": "credit",
+    "firebaseKey": "-NspU6ALw-cNIgTkRE27",
+    "uid": null
+  },
+  "-NspU6ANVW8wJToBTun9": {
+    "name": "Fletcher Moore",
+    "isOpen": true,
+    "customerPhone": "(504) 334-7570",
+    "customerEmail": "vcastillac@europa.eu",
+    "orderType": "debit",
+    "firebaseKey": "-NspU6ANVW8wJToBTun9",
+    "uid": null
+  },
+  "-NspU6AOSdB89Sc883ps": {
+    "name": "Fletcher Moore",
+    "isOpen": true,
+    "customerPhone": "(130) 351-7186",
+    "customerEmail": "rbridied@biglobe.ne.jp",
+    "orderType": "Mobile",
+    "firebaseKey": "-NspU6AOSdB89Sc883ps",
+    "uid": null
+  },
+  "-NspU6BOPd1DCtGrrw9f": {
+    "name": "Fletcher Moore",
+    "isOpen": true,
+    "customerPhone": "(203) 796-0780",
+    "customerEmail": "smanuellie@cocolog-nifty.com",
+    "orderType": "credit",
+    "firebaseKey": "-NspU6BOPd1DCtGrrw9f",
+    "uid": null
+  },
+  "-NspU6BQACiG4XiyAIWo": {
+    "name": "Fletcher Moore",
+    "isOpen": true,
+    "customerPhone": "(200) 492-6046",
+    "customerEmail": "jshovelinf@so-net.ne.jp",
+    "orderType": "cash",
+    "firebaseKey": "-NspU6BQACiG4XiyAIWo",
+    "uid": null
+  }
+}


### PR DESCRIPTION
## Description
We used Mockroo to create the orders data and items data. Once data was generated we uploaded the information into the file json file it belonged in.

## Related Issue
This pull request is related to the "Getting Started" milestone. 

## Motivation and Context
This data was generated so that we have 4 orders already created for each user and 2 items for each user.
This is the information the code will be built off and how we will index on specific keys. 

## How Can This Be Tested?
All of this data will be in our Firebase and tested in Postman.

## Screenshots (if appropriate):
![image](https://github.com/nss-evening-cohort-26/pos-terminal-pixel-pioneers/assets/144184847/aa051787-c368-41b7-954e-39f9eefc0073)
![image](https://github.com/nss-evening-cohort-26/pos-terminal-pixel-pioneers/assets/144184847/e97f0616-c78a-4a04-ab29-5b82ee4a9c14)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)